### PR TITLE
add sha-224 impl

### DIFF
--- a/test/sha2.cpp
+++ b/test/sha2.cpp
@@ -52,8 +52,10 @@ template<class H> std::string digest( std::vector<char> const & v )
 }
 
 using boost::hash2::sha2_256;
+using boost::hash2::sha2_224;
 
-int main()
+static
+void sha_256()
 {
     // https://en.wikipedia.org/wiki/SHA-2#Test_vectors
 
@@ -106,6 +108,55 @@ int main()
         std::vector<char> buf(1000000, 0x00);
         BOOST_TEST_EQ( digest<sha2_256>( buf ), std::string( "d29751f2649b32ff572b5e0a9f541ea660a50f94ff0beedfb0b692b924cc8025" ) );
     }
+}
 
+static
+void sha_224()
+{
+    // https://en.wikipedia.org/wiki/SHA-2#Test_vectors
+
+    BOOST_TEST_EQ( digest<sha2_224>( "" ), std::string( "d14a028c2a3a2bc9476102bb288234c415a2b01f828ea62ac5b3e42f" ) );
+
+    // https://csrc.nist.gov/CSRC/media/Projects/Cryptographic-Standards-and-Guidelines/documents/examples/SHA224.pdf
+    BOOST_TEST_EQ( digest<sha2_224>( "abc" ), std::string( "23097d223405d8228642a477bda255b32aadbce4bda0b3f7e36c9da7" ) );
+    BOOST_TEST_EQ( digest<sha2_224>( "abcdbcdecdefdefgefghfghighijhijkijkljklmklmnlmnomnopnopq" ), std::string( "75388b16512776cc5dba5da1fd890150b0c6455cb4f58b1952522525" ) );
+
+    // https://csrc.nist.gov/CSRC/media/Projects/Cryptographic-Standards-and-Guidelines/documents/examples/SHA2_Additional.pdf
+    BOOST_TEST_EQ( digest<sha2_224>( "\xff" ), std::string( "e33f9d75e6ae1369dbabf81b96b4591ae46bba30b591a6b6c62542b5" ) );
+    BOOST_TEST_EQ( digest<sha2_224>( "\xe5\xe0\x99\x24" ), std::string( "fd19e74690d291467ce59f077df311638f1c3a46e510d0e49a67062d" ) );
+
+    {
+        char buf[ 56 ] = { 0 };
+        BOOST_TEST_EQ( digest<sha2_224>( buf ), std::string( "5c3e25b69d0ea26f260cfae87e23759e1eca9d1ecc9fbf3c62266804" ) );
+    }
+
+    {
+        char buf[ 1000 ] = {};
+        for( auto& c : buf ) c = 'Q';
+        BOOST_TEST_EQ( digest<sha2_224>( buf ), std::string( "3706197f66890a41779dc8791670522e136fafa24874685715bd0a8a" ) );
+    }
+
+    {
+        char buf[ 1000 ] = {};
+        for( auto& c : buf ) c = 'A';
+        BOOST_TEST_EQ( digest<sha2_224>( buf ), std::string( "a8d0c66b5c6fdfd836eb3c6d04d32dfe66c3b1f168b488bf4c9c66ce" ) );
+    }
+
+    {
+        char buf[ 1005 ] = {};
+        for( auto& c : buf ) c = '\x99';
+        BOOST_TEST_EQ( digest<sha2_224>( buf ), std::string( "cb00ecd03788bf6c0908401e0eb053ac61f35e7e20a2cfd7bd96d640" ) );
+    }
+
+    {
+        std::vector<char> buf(1000000, 0x00);
+        BOOST_TEST_EQ( digest<sha2_224>( buf ), std::string( "3a5d74b68f14f3a4b2be9289b8d370672d0b3d2f53bc303c59032df3" ) );
+    }
+}
+
+int main()
+{
+    sha_256();
+    sha_224();
     return boost::report_errors();
 }


### PR DESCRIPTION
This is a small prototype/idea of how to factor some of the common functionality into the same place.

Maybe the base can become templated on NTTPs and we can use this for the sha-512 variants.