### PR TITLE
sha-512

### DIFF
--- a/include/boost/hash2/detail/rot.hpp
+++ b/include/boost/hash2/detail/rot.hpp
@@ -34,6 +34,11 @@ BOOST_FORCEINLINE std::uint32_t rotr( std::uint32_t v, int k )
     return _rotr( v, k );
 }
 
+BOOST_FORCEINLINE std::uint64_t rotr( std::uint64_t v, int k )
+{
+    return _rotr64( v, k );
+}
+
 #else
 
 // k must not be 0
@@ -52,6 +57,11 @@ BOOST_FORCEINLINE std::uint64_t rotl( std::uint64_t v, int k )
 BOOST_FORCEINLINE std::uint32_t rotr( std::uint32_t v, int k )
 {
     return ( v >> k ) | ( v << ( 32 - k ) );
+}
+
+BOOST_FORCEINLINE std::uint64_t rotr( std::uint64_t v, int k )
+{
+    return ( v >> k ) | ( v << ( 64 - k ) );
 }
 
 #endif

--- a/include/boost/hash2/sha2.hpp
+++ b/include/boost/hash2/sha2.hpp
@@ -280,6 +280,220 @@ public:
     }
 };
 
+class sha2_512
+{
+private:
+
+    std::uint64_t state_[ 8 ];
+
+    static const int N = 128;
+
+    unsigned char buffer_[ N ];
+    std::size_t m_; // == n_ % N
+
+    std::uint64_t n_;
+
+private:
+
+    void init()
+    {
+        state_[ 0 ] = 0x6a09e667f3bcc908;
+        state_[ 1 ] = 0xbb67ae8584caa73b;
+        state_[ 2 ] = 0x3c6ef372fe94f82b;
+        state_[ 3 ] = 0xa54ff53a5f1d36f1;
+        state_[ 4 ] = 0x510e527fade682d1;
+        state_[ 5 ] = 0x9b05688c2b3e6c1f;
+        state_[ 6 ] = 0x1f83d9abfb41bd6b;
+        state_[ 7 ] = 0x5be0cd19137e2179;
+    }
+
+    static std::uint64_t Ch( std::uint64_t x, std::uint64_t y, std::uint64_t z ) noexcept
+    {
+        return ( x & y ) ^ ( ~x & z );
+    }
+
+    static std::uint64_t Maj( std::uint64_t x, std::uint64_t y, std::uint64_t z ) noexcept
+    {
+        return ( x & y ) ^ ( x & z ) ^ ( y & z );
+    }
+
+    static std::uint64_t Sigma0( std::uint64_t x ) noexcept
+    {
+        return detail::rotr( x, 28 ) ^ detail::rotr( x, 34 ) ^ detail::rotr( x, 39 );
+    }
+
+    static std::uint64_t Sigma1( std::uint64_t x ) noexcept
+    {
+        return detail::rotr( x, 14 ) ^ detail::rotr( x, 18 ) ^ detail::rotr( x, 41 );
+    }
+
+    static std::uint64_t sigma0( std::uint64_t x ) noexcept
+    {
+        return detail::rotr( x, 1 ) ^ detail::rotr( x, 8 ) ^ ( x >> 7 );
+    }
+
+    static std::uint64_t sigma1( std::uint64_t x ) noexcept
+    {
+        return detail::rotr( x, 19 ) ^ detail::rotr( x, 61 ) ^ ( x >> 6 );
+    }
+
+    void transform( unsigned char const block[ N ] )
+    {
+        constexpr static std::uint64_t const K[ 80 ] =
+        {
+            0x428a2f98d728ae22, 0x7137449123ef65cd, 0xb5c0fbcfec4d3b2f, 0xe9b5dba58189dbbc,
+            0x3956c25bf348b538, 0x59f111f1b605d019, 0x923f82a4af194f9b, 0xab1c5ed5da6d8118,
+            0xd807aa98a3030242, 0x12835b0145706fbe, 0x243185be4ee4b28c, 0x550c7dc3d5ffb4e2,
+            0x72be5d74f27b896f, 0x80deb1fe3b1696b1, 0x9bdc06a725c71235, 0xc19bf174cf692694,
+            0xe49b69c19ef14ad2, 0xefbe4786384f25e3, 0x0fc19dc68b8cd5b5, 0x240ca1cc77ac9c65,
+            0x2de92c6f592b0275, 0x4a7484aa6ea6e483, 0x5cb0a9dcbd41fbd4, 0x76f988da831153b5,
+            0x983e5152ee66dfab, 0xa831c66d2db43210, 0xb00327c898fb213f, 0xbf597fc7beef0ee4,
+            0xc6e00bf33da88fc2, 0xd5a79147930aa725, 0x06ca6351e003826f, 0x142929670a0e6e70,
+            0x27b70a8546d22ffc, 0x2e1b21385c26c926, 0x4d2c6dfc5ac42aed, 0x53380d139d95b3df,
+            0x650a73548baf63de, 0x766a0abb3c77b2a8, 0x81c2c92e47edaee6, 0x92722c851482353b,
+            0xa2bfe8a14cf10364, 0xa81a664bbc423001, 0xc24b8b70d0f89791, 0xc76c51a30654be30,
+            0xd192e819d6ef5218, 0xd69906245565a910, 0xf40e35855771202a, 0x106aa07032bbd1b8,
+            0x19a4c116b8d2d0c8, 0x1e376c085141ab53, 0x2748774cdf8eeb99, 0x34b0bcb5e19b48a8,
+            0x391c0cb3c5c95a63, 0x4ed8aa4ae3418acb, 0x5b9cca4f7763e373, 0x682e6ff3d6b2b8a3,
+            0x748f82ee5defb2fc, 0x78a5636f43172f60, 0x84c87814a1f0ab72, 0x8cc702081a6439ec,
+            0x90befffa23631e28, 0xa4506cebde82bde9, 0xbef9a3f7b2c67915, 0xc67178f2e372532b,
+            0xca273eceea26619c, 0xd186b8c721c0c207, 0xeada7dd6cde0eb1e, 0xf57d4f7fee6ed178,
+            0x06f067aa72176fba, 0x0a637dc5a2c898a6, 0x113f9804bef90dae, 0x1b710b35131c471b,
+            0x28db77f523047d84, 0x32caab7b40c72493, 0x3c9ebe0a15c9bebc, 0x431d67c49c100d4c,
+            0x4cc5d4becb3e42b6, 0x597f299cfc657e2a, 0x5fcb6fab3ad6faec, 0x6c44198c4a475817,
+        };
+
+        std::uint64_t W[ 80 ];
+
+        for( int t = 0; t < 16; ++t )
+        {
+            W[ t ] = detail::read64be( block + t * 8 );
+        }
+
+        for( int t = 16; t < 80; ++t )
+        {
+            W[ t ] = sigma1( W[ t - 2 ] ) + W[ t - 7 ] + sigma0( W[ t - 15 ] ) + W[ t - 16 ];
+        }
+
+        std::uint64_t a = state_[ 0 ];
+        std::uint64_t b = state_[ 1 ];
+        std::uint64_t c = state_[ 2 ];
+        std::uint64_t d = state_[ 3 ];
+        std::uint64_t e = state_[ 4 ];
+        std::uint64_t f = state_[ 5 ];
+        std::uint64_t g = state_[ 6 ];
+        std::uint64_t h = state_[ 7 ];
+
+        for( int t = 0; t < 80; ++t )
+        {
+            std::uint64_t T1 = h + Sigma1( e ) + Ch( e, f, g ) + K[ t ] + W[ t ];
+            std::uint64_t T2 = Sigma0( a ) + Maj( a, b, c );
+
+            h = g;
+            g = f;
+            f = e;
+            e = d + T1;
+            d = c;
+            c = b;
+            b = a;
+            a = T1 + T2;
+        }
+
+        state_[ 0 ] += a;
+        state_[ 1 ] += b;
+        state_[ 2 ] += c;
+        state_[ 3 ] += d;
+        state_[ 4 ] += e;
+        state_[ 5 ] += f;
+        state_[ 6 ] += g;
+        state_[ 7 ] += h;
+    }
+
+public:
+
+    using result_type = std::array<unsigned char, 64>;
+
+    sha2_512(): m_( 0 ), n_( 0 )
+    {
+        init();
+    }
+
+    void update( void const * pv, std::size_t n )
+    {
+        unsigned char const* p = static_cast<unsigned char const*>( pv );
+
+        BOOST_ASSERT( m_ == n_ % N );
+
+        n_ += n;
+
+        if( m_ > 0 )
+        {
+            std::size_t k = N - m_;
+
+            if( n < k )
+            {
+                k = n;
+            }
+
+            std::memcpy( buffer_ + m_, p, k );
+
+            p += k;
+            n -= k;
+            m_ += k;
+
+            if( m_ < N ) return;
+
+            BOOST_ASSERT( m_ == N );
+
+            transform( buffer_ );
+            m_ = 0;
+
+            std::memset( buffer_, 0, N );
+        }
+
+        BOOST_ASSERT( m_ == 0 );
+
+        while( n >= N )
+        {
+            transform( p );
+
+            p += N;
+            n -= N;
+        }
+
+        BOOST_ASSERT( n < N );
+
+        if( n > 0 )
+        {
+            std::memcpy( buffer_, p, n );
+            m_ = n;
+        }
+
+        BOOST_ASSERT( m_ == n_ % N );
+    }
+
+    result_type result()
+    {
+        unsigned char bits[ 16 ] = {};
+        detail::write64be( bits + 8, n_ * 8 );
+
+        std::size_t k = m_ < (N - 16) ? (N - 16) - m_ : N + ( N - 16 ) - m_;
+        unsigned char padding[ N ] = { 0x80 };
+
+        update( padding, k );
+        update( bits, 16 );
+        BOOST_ASSERT( m_ == 0 );
+
+        result_type digest;
+        for( int i = 0; i < 8; ++i )
+        {
+            detail::write64be( &digest[ i * 8 ], state_[ i ] );
+        }
+
+        return digest;
+    }
+};
+
 } // namespace hash2
 } // namespace boost
 

--- a/include/boost/hash2/sha2.hpp
+++ b/include/boost/hash2/sha2.hpp
@@ -24,21 +24,79 @@ namespace hash2
 namespace detail
 {
 
-struct sha2_256_base
+template<class Word, class Algo, int M>
+struct sha2_base
 {
-    std::uint32_t state_[ 8 ];
+    Word state_[ 8 ];
 
-    static const int N = 64;
+    static int const N = M;
 
     unsigned char buffer_[ N ];
     std::size_t m_; // == n_ % N
 
     std::uint64_t n_;
 
-    sha2_256_base(): m_( 0 ), n_( 0 )
+    sha2_base(): m_( 0 ), n_( 0 )
     {
     }
 
+    void update( void const * pv, std::size_t n )
+    {
+        unsigned char const* p = static_cast<unsigned char const*>( pv );
+
+        BOOST_ASSERT( m_ == n_ % N );
+
+        n_ += n;
+
+        if( m_ > 0 )
+        {
+            std::size_t k = N - m_;
+
+            if( n < k )
+            {
+                k = n;
+            }
+
+            std::memcpy( buffer_ + m_, p, k );
+
+            p += k;
+            n -= k;
+            m_ += k;
+
+            if( m_ < N ) return;
+
+            BOOST_ASSERT( m_ == N );
+
+            Algo::transform( buffer_, state_ );
+            m_ = 0;
+
+            std::memset( buffer_, 0, N );
+        }
+
+        BOOST_ASSERT( m_ == 0 );
+
+        while( n >= N )
+        {
+            Algo::transform( p, state_ );
+
+            p += N;
+            n -= N;
+        }
+
+        BOOST_ASSERT( n < N );
+
+        if( n > 0 )
+        {
+            std::memcpy( buffer_, p, n );
+            m_ = n;
+        }
+
+        BOOST_ASSERT( m_ == n_ % N );
+    }
+};
+
+struct sha2_256_base : public sha2_base<std::uint32_t, sha2_256_base, 64>
+{
     static std::uint32_t Sigma0( std::uint32_t x ) noexcept
     {
         return detail::rotr( x, 2 ) ^ detail::rotr( x, 13 ) ^ detail::rotr( x, 22 );
@@ -69,7 +127,7 @@ struct sha2_256_base
         return ( x & y ) ^ ( x & z ) ^ ( y & z );
     }
 
-    void transform( unsigned char const block[ 64 ] )
+    static void transform( unsigned char const block[ 64 ], std::uint32_t state[ 8 ] )
     {
         constexpr static std::uint32_t const K[ 64 ] =
         {
@@ -95,14 +153,14 @@ struct sha2_256_base
             W[ t ] = ( sigma1( W[ t - 2 ] ) + W[ t - 7] + sigma0( W[ t - 15 ] ) + W[ t - 16 ] );
         }
 
-        std::uint32_t a = state_[ 0 ];
-        std::uint32_t b = state_[ 1 ];
-        std::uint32_t c = state_[ 2 ];
-        std::uint32_t d = state_[ 3 ];
-        std::uint32_t e = state_[ 4 ];
-        std::uint32_t f = state_[ 5 ];
-        std::uint32_t g = state_[ 6 ];
-        std::uint32_t h = state_[ 7 ];
+        std::uint32_t a = state[ 0 ];
+        std::uint32_t b = state[ 1 ];
+        std::uint32_t c = state[ 2 ];
+        std::uint32_t d = state[ 3 ];
+        std::uint32_t e = state[ 4 ];
+        std::uint32_t f = state[ 5 ];
+        std::uint32_t g = state[ 6 ];
+        std::uint32_t h = state[ 7 ];
 
         for( int t = 0; t < 64; ++t )
         {
@@ -119,68 +177,120 @@ struct sha2_256_base
             a = (T1 + T2);
         }
 
-        state_[0] += a;
-        state_[1] += b;
-        state_[2] += c;
-        state_[3] += d;
-        state_[4] += e;
-        state_[5] += f;
-        state_[6] += g;
-        state_[7] += h;
+        state[0] += a;
+        state[1] += b;
+        state[2] += c;
+        state[3] += d;
+        state[4] += e;
+        state[5] += f;
+        state[6] += g;
+        state[7] += h;
     }
 
-    void update( void const * pv, std::size_t n )
+};
+
+struct sha2_512_base : public sha2_base<std::uint64_t, sha2_512_base, 128>
+{
+    static std::uint64_t Ch( std::uint64_t x, std::uint64_t y, std::uint64_t z ) noexcept
     {
-        unsigned char const* p = static_cast<unsigned char const*>( pv );
+        return ( x & y ) ^ ( ~x & z );
+    }
 
-        BOOST_ASSERT( m_ == n_ % N );
+    static std::uint64_t Maj( std::uint64_t x, std::uint64_t y, std::uint64_t z ) noexcept
+    {
+        return ( x & y ) ^ ( x & z ) ^ ( y & z );
+    }
 
-        n_ += n;
+    static std::uint64_t Sigma0( std::uint64_t x ) noexcept
+    {
+        return detail::rotr( x, 28 ) ^ detail::rotr( x, 34 ) ^ detail::rotr( x, 39 );
+    }
 
-        if( m_ > 0 )
+    static std::uint64_t Sigma1( std::uint64_t x ) noexcept
+    {
+        return detail::rotr( x, 14 ) ^ detail::rotr( x, 18 ) ^ detail::rotr( x, 41 );
+    }
+
+    static std::uint64_t sigma0( std::uint64_t x ) noexcept
+    {
+        return detail::rotr( x, 1 ) ^ detail::rotr( x, 8 ) ^ ( x >> 7 );
+    }
+
+    static std::uint64_t sigma1( std::uint64_t x ) noexcept
+    {
+        return detail::rotr( x, 19 ) ^ detail::rotr( x, 61 ) ^ ( x >> 6 );
+    }
+
+    static void transform( unsigned char const block[ 128 ], std::uint64_t state[ 8 ] )
+    {
+        constexpr static std::uint64_t const K[ 80 ] =
         {
-            std::size_t k = N - m_;
+            0x428a2f98d728ae22, 0x7137449123ef65cd, 0xb5c0fbcfec4d3b2f, 0xe9b5dba58189dbbc,
+            0x3956c25bf348b538, 0x59f111f1b605d019, 0x923f82a4af194f9b, 0xab1c5ed5da6d8118,
+            0xd807aa98a3030242, 0x12835b0145706fbe, 0x243185be4ee4b28c, 0x550c7dc3d5ffb4e2,
+            0x72be5d74f27b896f, 0x80deb1fe3b1696b1, 0x9bdc06a725c71235, 0xc19bf174cf692694,
+            0xe49b69c19ef14ad2, 0xefbe4786384f25e3, 0x0fc19dc68b8cd5b5, 0x240ca1cc77ac9c65,
+            0x2de92c6f592b0275, 0x4a7484aa6ea6e483, 0x5cb0a9dcbd41fbd4, 0x76f988da831153b5,
+            0x983e5152ee66dfab, 0xa831c66d2db43210, 0xb00327c898fb213f, 0xbf597fc7beef0ee4,
+            0xc6e00bf33da88fc2, 0xd5a79147930aa725, 0x06ca6351e003826f, 0x142929670a0e6e70,
+            0x27b70a8546d22ffc, 0x2e1b21385c26c926, 0x4d2c6dfc5ac42aed, 0x53380d139d95b3df,
+            0x650a73548baf63de, 0x766a0abb3c77b2a8, 0x81c2c92e47edaee6, 0x92722c851482353b,
+            0xa2bfe8a14cf10364, 0xa81a664bbc423001, 0xc24b8b70d0f89791, 0xc76c51a30654be30,
+            0xd192e819d6ef5218, 0xd69906245565a910, 0xf40e35855771202a, 0x106aa07032bbd1b8,
+            0x19a4c116b8d2d0c8, 0x1e376c085141ab53, 0x2748774cdf8eeb99, 0x34b0bcb5e19b48a8,
+            0x391c0cb3c5c95a63, 0x4ed8aa4ae3418acb, 0x5b9cca4f7763e373, 0x682e6ff3d6b2b8a3,
+            0x748f82ee5defb2fc, 0x78a5636f43172f60, 0x84c87814a1f0ab72, 0x8cc702081a6439ec,
+            0x90befffa23631e28, 0xa4506cebde82bde9, 0xbef9a3f7b2c67915, 0xc67178f2e372532b,
+            0xca273eceea26619c, 0xd186b8c721c0c207, 0xeada7dd6cde0eb1e, 0xf57d4f7fee6ed178,
+            0x06f067aa72176fba, 0x0a637dc5a2c898a6, 0x113f9804bef90dae, 0x1b710b35131c471b,
+            0x28db77f523047d84, 0x32caab7b40c72493, 0x3c9ebe0a15c9bebc, 0x431d67c49c100d4c,
+            0x4cc5d4becb3e42b6, 0x597f299cfc657e2a, 0x5fcb6fab3ad6faec, 0x6c44198c4a475817,
+        };
 
-            if( n < k )
-            {
-                k = n;
-            }
+        std::uint64_t W[ 80 ];
 
-            std::memcpy( buffer_ + m_, p, k );
-
-            p += k;
-            n -= k;
-            m_ += k;
-
-            if( m_ < N ) return;
-
-            BOOST_ASSERT( m_ == N );
-
-            transform( buffer_ );
-            m_ = 0;
-
-            std::memset( buffer_, 0, N );
+        for( int t = 0; t < 16; ++t )
+        {
+            W[ t ] = detail::read64be( block + t * 8 );
         }
 
-        BOOST_ASSERT( m_ == 0 );
-
-        while( n >= N )
+        for( int t = 16; t < 80; ++t )
         {
-            transform( p );
-
-            p += N;
-            n -= N;
+            W[ t ] = sigma1( W[ t - 2 ] ) + W[ t - 7 ] + sigma0( W[ t - 15 ] ) + W[ t - 16 ];
         }
 
-        BOOST_ASSERT( n < N );
+        std::uint64_t a = state[ 0 ];
+        std::uint64_t b = state[ 1 ];
+        std::uint64_t c = state[ 2 ];
+        std::uint64_t d = state[ 3 ];
+        std::uint64_t e = state[ 4 ];
+        std::uint64_t f = state[ 5 ];
+        std::uint64_t g = state[ 6 ];
+        std::uint64_t h = state[ 7 ];
 
-        if( n > 0 )
+        for( int t = 0; t < 80; ++t )
         {
-            std::memcpy( buffer_, p, n );
-            m_ = n;
+            std::uint64_t T1 = h + Sigma1( e ) + Ch( e, f, g ) + K[ t ] + W[ t ];
+            std::uint64_t T2 = Sigma0( a ) + Maj( a, b, c );
+
+            h = g;
+            g = f;
+            f = e;
+            e = d + T1;
+            d = c;
+            c = b;
+            b = a;
+            a = T1 + T2;
         }
 
-        BOOST_ASSERT( m_ == n_ % N );
+        state[ 0 ] += a;
+        state[ 1 ] += b;
+        state[ 2 ] += c;
+        state[ 3 ] += d;
+        state[ 4 ] += e;
+        state[ 5 ] += f;
+        state[ 6 ] += g;
+        state[ 7 ] += h;
     }
 };
 
@@ -225,7 +335,8 @@ public:
         BOOST_ASSERT( m_ == 0 );
 
         result_type digest;
-        for( int i = 0; i < 8; ++i ) {
+        for( int i = 0; i < 8; ++i )
+        {
             detail::write32be( &digest[ i * 4 ], state_[ i ] );
         }
 
@@ -280,19 +391,8 @@ public:
     }
 };
 
-class sha2_512
+class sha2_512 : detail::sha2_512_base
 {
-private:
-
-    std::uint64_t state_[ 8 ];
-
-    static const int N = 128;
-
-    unsigned char buffer_[ N ];
-    std::size_t m_; // == n_ % N
-
-    std::uint64_t n_;
-
 private:
 
     void init()
@@ -307,178 +407,23 @@ private:
         state_[ 7 ] = 0x5be0cd19137e2179;
     }
 
-    static std::uint64_t Ch( std::uint64_t x, std::uint64_t y, std::uint64_t z ) noexcept
-    {
-        return ( x & y ) ^ ( ~x & z );
-    }
-
-    static std::uint64_t Maj( std::uint64_t x, std::uint64_t y, std::uint64_t z ) noexcept
-    {
-        return ( x & y ) ^ ( x & z ) ^ ( y & z );
-    }
-
-    static std::uint64_t Sigma0( std::uint64_t x ) noexcept
-    {
-        return detail::rotr( x, 28 ) ^ detail::rotr( x, 34 ) ^ detail::rotr( x, 39 );
-    }
-
-    static std::uint64_t Sigma1( std::uint64_t x ) noexcept
-    {
-        return detail::rotr( x, 14 ) ^ detail::rotr( x, 18 ) ^ detail::rotr( x, 41 );
-    }
-
-    static std::uint64_t sigma0( std::uint64_t x ) noexcept
-    {
-        return detail::rotr( x, 1 ) ^ detail::rotr( x, 8 ) ^ ( x >> 7 );
-    }
-
-    static std::uint64_t sigma1( std::uint64_t x ) noexcept
-    {
-        return detail::rotr( x, 19 ) ^ detail::rotr( x, 61 ) ^ ( x >> 6 );
-    }
-
-    void transform( unsigned char const block[ N ] )
-    {
-        constexpr static std::uint64_t const K[ 80 ] =
-        {
-            0x428a2f98d728ae22, 0x7137449123ef65cd, 0xb5c0fbcfec4d3b2f, 0xe9b5dba58189dbbc,
-            0x3956c25bf348b538, 0x59f111f1b605d019, 0x923f82a4af194f9b, 0xab1c5ed5da6d8118,
-            0xd807aa98a3030242, 0x12835b0145706fbe, 0x243185be4ee4b28c, 0x550c7dc3d5ffb4e2,
-            0x72be5d74f27b896f, 0x80deb1fe3b1696b1, 0x9bdc06a725c71235, 0xc19bf174cf692694,
-            0xe49b69c19ef14ad2, 0xefbe4786384f25e3, 0x0fc19dc68b8cd5b5, 0x240ca1cc77ac9c65,
-            0x2de92c6f592b0275, 0x4a7484aa6ea6e483, 0x5cb0a9dcbd41fbd4, 0x76f988da831153b5,
-            0x983e5152ee66dfab, 0xa831c66d2db43210, 0xb00327c898fb213f, 0xbf597fc7beef0ee4,
-            0xc6e00bf33da88fc2, 0xd5a79147930aa725, 0x06ca6351e003826f, 0x142929670a0e6e70,
-            0x27b70a8546d22ffc, 0x2e1b21385c26c926, 0x4d2c6dfc5ac42aed, 0x53380d139d95b3df,
-            0x650a73548baf63de, 0x766a0abb3c77b2a8, 0x81c2c92e47edaee6, 0x92722c851482353b,
-            0xa2bfe8a14cf10364, 0xa81a664bbc423001, 0xc24b8b70d0f89791, 0xc76c51a30654be30,
-            0xd192e819d6ef5218, 0xd69906245565a910, 0xf40e35855771202a, 0x106aa07032bbd1b8,
-            0x19a4c116b8d2d0c8, 0x1e376c085141ab53, 0x2748774cdf8eeb99, 0x34b0bcb5e19b48a8,
-            0x391c0cb3c5c95a63, 0x4ed8aa4ae3418acb, 0x5b9cca4f7763e373, 0x682e6ff3d6b2b8a3,
-            0x748f82ee5defb2fc, 0x78a5636f43172f60, 0x84c87814a1f0ab72, 0x8cc702081a6439ec,
-            0x90befffa23631e28, 0xa4506cebde82bde9, 0xbef9a3f7b2c67915, 0xc67178f2e372532b,
-            0xca273eceea26619c, 0xd186b8c721c0c207, 0xeada7dd6cde0eb1e, 0xf57d4f7fee6ed178,
-            0x06f067aa72176fba, 0x0a637dc5a2c898a6, 0x113f9804bef90dae, 0x1b710b35131c471b,
-            0x28db77f523047d84, 0x32caab7b40c72493, 0x3c9ebe0a15c9bebc, 0x431d67c49c100d4c,
-            0x4cc5d4becb3e42b6, 0x597f299cfc657e2a, 0x5fcb6fab3ad6faec, 0x6c44198c4a475817,
-        };
-
-        std::uint64_t W[ 80 ];
-
-        for( int t = 0; t < 16; ++t )
-        {
-            W[ t ] = detail::read64be( block + t * 8 );
-        }
-
-        for( int t = 16; t < 80; ++t )
-        {
-            W[ t ] = sigma1( W[ t - 2 ] ) + W[ t - 7 ] + sigma0( W[ t - 15 ] ) + W[ t - 16 ];
-        }
-
-        std::uint64_t a = state_[ 0 ];
-        std::uint64_t b = state_[ 1 ];
-        std::uint64_t c = state_[ 2 ];
-        std::uint64_t d = state_[ 3 ];
-        std::uint64_t e = state_[ 4 ];
-        std::uint64_t f = state_[ 5 ];
-        std::uint64_t g = state_[ 6 ];
-        std::uint64_t h = state_[ 7 ];
-
-        for( int t = 0; t < 80; ++t )
-        {
-            std::uint64_t T1 = h + Sigma1( e ) + Ch( e, f, g ) + K[ t ] + W[ t ];
-            std::uint64_t T2 = Sigma0( a ) + Maj( a, b, c );
-
-            h = g;
-            g = f;
-            f = e;
-            e = d + T1;
-            d = c;
-            c = b;
-            b = a;
-            a = T1 + T2;
-        }
-
-        state_[ 0 ] += a;
-        state_[ 1 ] += b;
-        state_[ 2 ] += c;
-        state_[ 3 ] += d;
-        state_[ 4 ] += e;
-        state_[ 5 ] += f;
-        state_[ 6 ] += g;
-        state_[ 7 ] += h;
-    }
-
 public:
 
     using result_type = std::array<unsigned char, 64>;
+    using detail::sha2_512_base::update;
 
-    sha2_512(): m_( 0 ), n_( 0 )
+    sha2_512()
     {
         init();
     }
 
-    void update( void const * pv, std::size_t n )
-    {
-        unsigned char const* p = static_cast<unsigned char const*>( pv );
-
-        BOOST_ASSERT( m_ == n_ % N );
-
-        n_ += n;
-
-        if( m_ > 0 )
-        {
-            std::size_t k = N - m_;
-
-            if( n < k )
-            {
-                k = n;
-            }
-
-            std::memcpy( buffer_ + m_, p, k );
-
-            p += k;
-            n -= k;
-            m_ += k;
-
-            if( m_ < N ) return;
-
-            BOOST_ASSERT( m_ == N );
-
-            transform( buffer_ );
-            m_ = 0;
-
-            std::memset( buffer_, 0, N );
-        }
-
-        BOOST_ASSERT( m_ == 0 );
-
-        while( n >= N )
-        {
-            transform( p );
-
-            p += N;
-            n -= N;
-        }
-
-        BOOST_ASSERT( n < N );
-
-        if( n > 0 )
-        {
-            std::memcpy( buffer_, p, n );
-            m_ = n;
-        }
-
-        BOOST_ASSERT( m_ == n_ % N );
-    }
-
     result_type result()
     {
-        unsigned char bits[ 16 ] = {};
+        unsigned char bits[ 16 ] = { 0 };
         detail::write64be( bits + 8, n_ * 8 );
 
-        std::size_t k = m_ < (N - 16) ? (N - 16) - m_ : N + ( N - 16 ) - m_;
-        unsigned char padding[ N ] = { 0x80 };
+        std::size_t k = m_ < 112 ? 112 - m_ : 128 + 112 - m_;
+        unsigned char padding[ 128 ] = { 0x80 };
 
         update( padding, k );
         update( bits, 16 );

--- a/test/sha2.cpp
+++ b/test/sha2.cpp
@@ -51,12 +51,11 @@ template<class H> std::string digest( std::vector<char> const & v )
     return to_string( h.result() );
 }
 
-using boost::hash2::sha2_256;
-using boost::hash2::sha2_224;
-
 static
 void sha_256()
 {
+    using boost::hash2::sha2_256;
+
     // https://en.wikipedia.org/wiki/SHA-2#Test_vectors
 
     BOOST_TEST_EQ( digest<sha2_256>( "" ), std::string( "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855" ) );
@@ -113,6 +112,8 @@ void sha_256()
 static
 void sha_224()
 {
+    using boost::hash2::sha2_224;
+
     // https://en.wikipedia.org/wiki/SHA-2#Test_vectors
 
     BOOST_TEST_EQ( digest<sha2_224>( "" ), std::string( "d14a028c2a3a2bc9476102bb288234c415a2b01f828ea62ac5b3e42f" ) );
@@ -154,9 +155,72 @@ void sha_224()
     }
 }
 
+static
+void sha_512()
+{
+    using boost::hash2::sha2_512;
+
+    // https://en.wikipedia.org/wiki/SHA-2#Test_vectors
+    BOOST_TEST_EQ( digest<sha2_512>( "" ), std::string( "cf83e1357eefb8bdf1542850d66d8007d620e4050b5715dc83f4a921d36ce9ce47d0d13c5d85f2b0ff8318d2877eec2f63b931bd47417a81a538327af927da3e" ) );
+
+    // https://csrc.nist.gov/CSRC/media/Projects/Cryptographic-Standards-and-Guidelines/documents/examples/SHA512.pdf
+    BOOST_TEST_EQ( digest<sha2_512>( "abc" ), std::string( "ddaf35a193617abacc417349ae20413112e6fa4e89a97ea20a9eeee64b55d39a2192992a274fc1a836ba3c23a3feebbd454d4423643ce80e2a9ac94fa54ca49f" ) );
+    BOOST_TEST_EQ( digest<sha2_512>( "abcdefghbcdefghicdefghijdefghijkefghijklfghijklmghijklmnhijklmnoijklmnopjklmnopqklmnopqrlmnopqrsmnopqrstnopqrstu" ), std::string( "8e959b75dae313da8cf4f72814fc143f8f7779c6eb9f7fa17299aeadb6889018501d289e4900f7e4331b99dec4b5433ac7d329eeb6dd26545e96e55b874be909" ) );
+
+    // https://csrc.nist.gov/CSRC/media/Projects/Cryptographic-Standards-and-Guidelines/documents/examples/SHA2_Additional.pdf
+    {
+        char buf[ 111 ] = {};
+        for( auto& c : buf ) c = 0;
+        BOOST_TEST_EQ( digest<sha2_512>( buf ), std::string( "77ddd3a542e530fd047b8977c657ba6ce72f1492e360b2b2212cd264e75ec03882e4ff0525517ab4207d14c70c2259ba88d4d335ee0e7e20543d22102ab1788c" ) );
+    }
+
+    {
+        char buf[ 112 ] = {};
+        for( auto& c : buf ) c = 0;
+        BOOST_TEST_EQ( digest<sha2_512>( buf ), std::string( "2be2e788c8a8adeaa9c89a7f78904cacea6e39297d75e0573a73c756234534d6627ab4156b48a6657b29ab8beb73334040ad39ead81446bb09c70704ec707952" ) );
+    }
+
+    {
+        char buf[ 113 ] = {};
+        for( auto& c : buf ) c = 0;
+        BOOST_TEST_EQ( digest<sha2_512>( buf ), std::string( "0e67910bcf0f9ccde5464c63b9c850a12a759227d16b040d98986d54253f9f34322318e56b8feb86c5fb2270ed87f31252f7f68493ee759743909bd75e4bb544" ) );
+    }
+
+    {
+        char buf[ 122 ] = {};
+        for( auto& c : buf ) c = 0;
+        BOOST_TEST_EQ( digest<sha2_512>( buf ), std::string( "4f3f095d015be4a7a7cc0b8c04da4aa09e74351e3a97651f744c23716ebd9b3e822e5077a01baa5cc0ed45b9249e88ab343d4333539df21ed229da6f4a514e0f" ) );
+    }
+
+    {
+        char buf[ 1000 ] = {};
+        for( auto& c : buf ) c = 0;
+        BOOST_TEST_EQ( digest<sha2_512>( buf ), std::string( "ca3dff61bb23477aa6087b27508264a6f9126ee3a004f53cb8db942ed345f2f2d229b4b59c859220a1cf1913f34248e3803bab650e849a3d9a709edc09ae4a76" ) );
+    }
+
+    {
+        char buf[ 1000 ] = {};
+        for( auto& c : buf ) c = 'A';
+        BOOST_TEST_EQ( digest<sha2_512>( buf ), std::string( "329c52ac62d1fe731151f2b895a00475445ef74f50b979c6f7bb7cae349328c1d4cb4f7261a0ab43f936a24b000651d4a824fcdd577f211aef8f806b16afe8af" ) );
+    }
+
+    {
+        char buf[ 1005 ] = {};
+        for( auto& c : buf ) c = 'U';
+        BOOST_TEST_EQ( digest<sha2_512>( buf ), std::string( "59f5e54fe299c6a8764c6b199e44924a37f59e2b56c3ebad939b7289210dc8e4c21b9720165b0f4d4374c90f1bf4fb4a5ace17a1161798015052893a48c3d161" ) );
+    }
+
+    {
+        std::vector<char> buf(1000000, 0x00);
+        BOOST_TEST_EQ( digest<sha2_512>( buf ), std::string( "ce044bc9fd43269d5bbc946cbebc3bb711341115cc4abdf2edbc3ff2c57ad4b15deb699bda257fea5aef9c6e55fcf4cf9dc25a8c3ce25f2efe90908379bff7ed" ) );
+    }
+
+}
+
 int main()
 {
     sha_256();
     sha_224();
+    sha_512();
     return boost::report_errors();
 }


### PR DESCRIPTION
Adds sha-512 impl

Refactors sha2 core to use a common base for storing state and handling parsing of the input. Maybe this can be done in a cleaner way?