### PR TITLE
Remove dependencies on Boost.StaticAssert

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -69,7 +69,6 @@ if(CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
 
   # secondaries
 
-  static_assert
   throw_exception
   io
   preprocessor


### PR DESCRIPTION
Boost.StaticAssert has been merged into Boost.Config, so remove the dependency.